### PR TITLE
add plug-and-play asset publishing for web previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,42 @@ No migration is required unless you want the new capabilities.
 - **`list_workflows`**: List all available workflows
 - **`run_workflow`**: Run any workflow with custom parameters
 
+### Publish Tools
+
+- **`get_publish_info`**: Show publish status (detected project root, publish dir, ComfyUI output root, and any missing setup)
+- **`set_comfyui_output_root`**: Set ComfyUI output directory (recommended for Comfy Desktop / nonstandard installs; persisted across restarts)
+- **`publish_asset`**: Publish a generated asset into the project's web directory with deterministic compression (default 600KB)
+
+**Publish Notes:**
+- **Session-scoped**: `asset_id`s are valid only for the current server session; restart invalidates them.
+- **Zero-config in common cases**: Publish dir auto-detected (`public/gen`, `static/gen`, or `assets/gen`); if ComfyUI output can't be detected, set it once via `set_comfyui_output_root`.
+- **Two modes**: Demo (explicit filename) and Library (auto filename + manifest update). In library mode, `manifest_key` is required.
+- **Manifest**: Updated only when `manifest_key` is provided.
+- **Compression**: Deterministic ladder to meet size limits; fails with a clear error if it can't.
+
+**Quick Start:**
+
+Example agent conversation flow:
+
+**User:** "Generate a hero image for my website and publish it as hero.webp"
+
+**Agent:** *Checks publish configuration*
+- Calls `get_publish_info()` → sees status "ready"
+
+**Agent:** *Generates image*
+- Calls `generate_image(prompt="a hero image for a website")` → gets `asset_id`
+
+**Agent:** *Publishes asset*
+- Calls `publish_asset(asset_id="...", target_filename="hero.webp")` → success
+
+**User:** "Now generate a logo and add it to the manifest as 'site-logo'"
+
+**Agent:** *Generates and publishes with manifest*
+- Calls `generate_image(prompt="a modern logo")` → gets `asset_id`
+- Calls `publish_asset(asset_id="...", manifest_key="site-logo")` → auto-generates filename, updates manifest
+
+See [docs/HOW_TO_TEST_PUBLISH.md](docs/HOW_TO_TEST_PUBLISH.md) for detailed usage and testing instructions.
+
 ## Custom Workflows
 
 Add custom workflows by placing JSON files in the `workflows/` directory. Workflows are automatically discovered and exposed as MCP tools.

--- a/managers/publish_manager.py
+++ b/managers/publish_manager.py
@@ -1,0 +1,1092 @@
+"""Publish manager for safely publishing ComfyUI assets to web project directories"""
+
+import json
+import logging
+import os
+import platform
+import re
+import shutil
+import threading
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+try:
+    from PIL import Image
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+logger = logging.getLogger("MCP_Server")
+
+# Target filename validation regex: simple filename only, no paths
+TARGET_FILENAME_REGEX = re.compile(r'^[a-z0-9][a-z0-9._-]{0,63}\.(webp|png|jpg|jpeg)$')
+# Manifest key validation regex: same as target_filename but no extension
+MANIFEST_KEY_REGEX = re.compile(r'^[a-z0-9][a-z0-9._-]{0,63}$')
+
+
+def get_publish_config_dir() -> Path:
+    """Get platform-specific config directory for publish settings.
+    
+    Returns:
+        Windows: %APPDATA%/comfyui-mcp-server
+        Mac: ~/Library/Application Support/comfyui-mcp-server
+        Linux: ~/.config/comfyui-mcp-server
+    """
+    system = platform.system()
+    if system == "Windows":
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata) / "comfyui-mcp-server"
+        # Fallback to user home
+        return Path.home() / "AppData" / "Roaming" / "comfyui-mcp-server"
+    elif system == "Darwin":  # macOS
+        return Path.home() / "Library" / "Application Support" / "comfyui-mcp-server"
+    else:  # Linux and others
+        return Path.home() / ".config" / "comfyui-mcp-server"
+
+
+def get_publish_config_file() -> Path:
+    """Get path to publish config file."""
+    return get_publish_config_dir() / "publish_config.json"
+
+
+def load_publish_config() -> Dict[str, Any]:
+    """Load persistent publish configuration.
+    
+    Returns:
+        Config dict with keys like 'comfyui_output_root'
+    """
+    config_file = get_publish_config_file()
+    if not config_file.exists():
+        return {}
+    
+    try:
+        with open(config_file, "r", encoding="utf-8") as f:
+            config = json.load(f)
+            return config if isinstance(config, dict) else {}
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning(f"Failed to load publish config from {config_file}: {e}")
+        return {}
+
+
+def save_publish_config(config: Dict[str, Any]) -> bool:
+    """Save persistent publish configuration.
+    
+    Args:
+        config: Config dict to save
+    
+    Returns:
+        True if successful, False otherwise
+    """
+    config_file = get_publish_config_file()
+    config_dir = config_file.parent
+    
+    try:
+        # Ensure config directory exists
+        config_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Load existing config to merge
+        existing = load_publish_config()
+        existing.update(config)
+        
+        # Save merged config
+        with open(config_file, "w", encoding="utf-8") as f:
+            json.dump(existing, f, indent=2)
+        
+        logger.info(f"Saved publish config to {config_file}")
+        return True
+    except (IOError, OSError) as e:
+        logger.error(f"Failed to save publish config to {config_file}: {e}")
+        return False
+
+
+def canonicalize_path(path: Union[str, Path], must_exist: bool = True) -> Path:
+    """Resolve path to absolute real path (handles symlinks).
+    
+    Args:
+        path: Path to canonicalize (can be string or Path)
+        must_exist: If True, path must exist (default: True)
+    
+    Returns:
+        Absolute Path object with symlinks resolved
+    
+    Raises:
+        ValueError: If path cannot be resolved and must_exist=True
+    """
+    try:
+        if must_exist:
+            resolved = Path(path).resolve(strict=True)
+        else:
+            # For non-existent paths, resolve without strict check
+            # This still resolves symlinks in parent directories
+            resolved = Path(path).resolve()
+        return resolved
+    except (OSError, RuntimeError) as e:
+        if must_exist:
+            raise ValueError(f"Cannot resolve path {path}: {e}")
+        # For non-existent paths, still try to resolve (may fail on invalid parent)
+        try:
+            return Path(path).resolve()
+        except (OSError, RuntimeError):
+            raise ValueError(f"Cannot resolve path {path}: {e}")
+
+
+def is_within(child_path: Union[str, Path], parent_path: Union[str, Path], child_must_exist: bool = True) -> bool:
+    """Check if child_path is within parent_path using real path resolution.
+    
+    Both paths are canonicalized (symlinks resolved) before comparison.
+    This prevents path traversal attacks via symlinks.
+    
+    Args:
+        child_path: Path to check (can be string or Path)
+        parent_path: Parent directory to check against (can be string or Path)
+        child_must_exist: If True, child path must exist (default: True)
+    
+    Returns:
+        True if child_path is within parent_path, False otherwise
+    """
+    try:
+        child_real = canonicalize_path(child_path, must_exist=child_must_exist)
+        parent_real = canonicalize_path(parent_path, must_exist=True)  # Parent should always exist
+        
+        # Use Path.is_relative_to() if available (Python 3.9+)
+        # Otherwise, check if commonpath equals parent path
+        if hasattr(Path, 'is_relative_to'):
+            # Python 3.9+
+            try:
+                return child_real.is_relative_to(parent_real)
+            except (ValueError, TypeError):
+                # Different drives or invalid paths
+                return False
+        else:
+            # Python < 3.9 fallback
+            try:
+                common = os.path.commonpath([str(child_real), str(parent_real)])
+                return os.path.normpath(common) == os.path.normpath(str(parent_real))
+            except ValueError:
+                # Paths on different drives (Windows) or invalid
+                return False
+    except (ValueError, OSError):
+        return False
+
+
+def detect_project_root() -> Tuple[Path, str]:
+    """Detect project root directory.
+    
+    Primary contract: server should be started from repo root (cwd).
+    Conservative fallback: search upward for project markers.
+    
+    Returns:
+        Tuple of (project_root Path, detection_method string)
+        detection_method: "cwd" | "auto-detected" | "error"
+    
+    Raises:
+        ValueError: If detection is ambiguous or fails
+    """
+    cwd = Path.cwd()
+    
+    # Primary: use cwd (expected usage)
+    # Check if cwd looks like a project root
+    project_markers = [".git", "package.json", "pyproject.toml", "Cargo.toml"]
+    has_markers = any((cwd / marker).exists() for marker in project_markers)
+    has_public = (cwd / "public").exists() or (cwd / "static").exists()
+    
+    if has_markers or has_public:
+        return cwd, "cwd"
+    
+    # Conservative fallback: search upward for markers
+    current = cwd
+    found_markers = []
+    
+    for _ in range(10):  # Limit search depth
+        markers_here = [m for m in project_markers if (current / m).exists()]
+        if markers_here:
+            found_markers.append((current, markers_here))
+        current = current.parent
+        if current == current.parent:  # Reached filesystem root
+            break
+    
+    if len(found_markers) == 0:
+        # No markers found, use cwd anyway (best guess)
+        logger.warning("No project markers found, using cwd as project root")
+        return cwd, "cwd"
+    elif len(found_markers) == 1:
+        # Single marker found, use it
+        project_root, _ = found_markers[0]
+        logger.info(f"Auto-detected project root: {project_root} (found markers: {found_markers[0][1]})")
+        return project_root, "auto-detected"
+    else:
+        # Multiple markers at different levels - ambiguous
+        levels = [str(p) for p, _ in found_markers]
+        raise ValueError(
+            f"Ambiguous project root detection. Found markers at multiple levels: {levels}. "
+            f"Please start the MCP server from the repo root (cwd)."
+        )
+
+
+def get_default_publish_root(project_root: Path) -> Path:
+    """Get default publish root directory.
+    
+    Tries in order: public/gen → static/gen → assets/gen
+    Creates directory if needed.
+    
+    Args:
+        project_root: Project root directory
+    
+    Returns:
+        Publish root directory (created if needed)
+    """
+    candidates = [
+        project_root / "public" / "gen",
+        project_root / "static" / "gen",
+        project_root / "assets" / "gen"
+    ]
+    
+    for candidate in candidates:
+        if candidate.parent.exists():
+            candidate.mkdir(parents=True, exist_ok=True)
+            return candidate
+    
+    # If none of the parent dirs exist, use public/gen (most common)
+    default = candidates[0]
+    default.mkdir(parents=True, exist_ok=True)
+    return default
+
+
+def validate_comfyui_output_root(path: Path) -> bool:
+    """Validate that a path looks like a ComfyUI output directory.
+    
+    Checks for ComfyUI patterns:
+    - ComfyUI_*.png files (strong indicator)
+    - Any image files (png, jpg, jpeg, webp) - ComfyUI outputs images
+    - output/ or temp/ subdirectories (ComfyUI structure)
+    - At least a few files (not empty)
+    
+    Args:
+        path: Path to validate
+    
+    Returns:
+        True if path looks like ComfyUI output, False otherwise
+    """
+    if not path.exists() or not path.is_dir():
+        return False
+    
+    # Strong indicator: ComfyUI_*.png files
+    comfyui_files = list(path.glob("ComfyUI_*.png"))
+    if comfyui_files:
+        return True
+    
+    # Check for output/ or temp/ subdirectories (ComfyUI structure)
+    if (path / "output").exists() or (path / "temp").exists():
+        return True
+    
+    # Lenient check: if directory has image files, it's probably ComfyUI output
+    # (ComfyUI typically outputs images directly to the output directory)
+    image_extensions = [".png", ".jpg", ".jpeg", ".webp", ".gif"]
+    image_files = []
+    for ext in image_extensions:
+        image_files.extend(path.glob(f"*{ext}"))
+        if len(image_files) >= 3:  # If we find a few images, it's likely ComfyUI output
+            return True
+    
+    return False
+
+
+def detect_comfyui_output_root(project_root: Path, comfyui_url: str = "http://localhost:8188") -> Tuple[Optional[Path], List[Dict[str, Any]]]:
+    """Detect ComfyUI output root directory (best-effort, tight candidates only).
+    
+    Detection order:
+    1. Persistent config (if set via set_comfyui_output_root tool)
+    2. Tight candidate list (2-5 paths only, no broad scanning)
+    
+    Args:
+        project_root: Project root directory
+        comfyui_url: ComfyUI server URL (unused for now, reserved for future API queries)
+    
+    Returns:
+        Tuple of (detected_path or None, list of tried paths with validation results)
+    """
+    tried_paths = []
+    
+    # 1. Check persistent config first (highest priority)
+    persistent_config = load_publish_config()
+    configured_path = persistent_config.get("comfyui_output_root")
+    if configured_path:
+        try:
+            resolved = Path(configured_path).resolve()
+            exists = resolved.exists() and resolved.is_dir()
+            is_valid = validate_comfyui_output_root(resolved) if exists else False
+            
+            tried_paths.append({
+                "path": str(resolved),
+                "exists": exists,
+                "is_valid": is_valid,
+                "source": "persistent_config"
+            })
+            
+            if is_valid:
+                logger.info(f"Using ComfyUI output root from persistent config: {resolved}")
+                return resolved, tried_paths
+            elif exists:
+                # Path exists but doesn't validate - still return it with warning
+                logger.warning(f"Configured ComfyUI output root exists but doesn't validate: {resolved}")
+                return resolved, tried_paths
+        except (OSError, ValueError) as e:
+            tried_paths.append({
+                "path": configured_path,
+                "exists": False,
+                "is_valid": False,
+                "source": "persistent_config",
+                "error": str(e)
+            })
+    
+    # 2. Tight candidate list (2-5 paths only, no broad scanning)
+    candidates = []
+    
+    # Relative to project root (common for dev setups)
+    candidates.append(project_root / "comfyui-desktop" / "output")
+    candidates.append(project_root.parent / "comfyui-desktop" / "output")
+    candidates.append(project_root / "ComfyUI" / "output")
+    
+    # User home (common for desktop installs)
+    candidates.append(Path.home() / "comfyui-desktop" / "output")
+    
+    # Platform-specific common location (one per platform, not scanning drives)
+    if os.name == "nt":  # Windows - check E: drive (user's specific location)
+        candidates.append(Path("E:/comfyui-desktop/output"))
+    # Don't scan C:, D:, etc. - that's what we're avoiding
+    
+    # Try each candidate
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+            exists = resolved.exists() and resolved.is_dir()
+            is_valid = validate_comfyui_output_root(resolved) if exists else False
+            
+            tried_paths.append({
+                "path": str(resolved),
+                "exists": exists,
+                "is_valid": is_valid,
+                "source": "auto_detection"
+            })
+            
+            if is_valid:
+                logger.info(f"Auto-detected ComfyUI output root: {resolved}")
+                return resolved, tried_paths
+        except (OSError, ValueError) as e:
+            tried_paths.append({
+                "path": str(candidate),
+                "exists": False,
+                "is_valid": False,
+                "source": "auto_detection",
+                "error": str(e)
+            })
+    
+    # None found
+    logger.warning(f"Could not detect ComfyUI output root. Tried {len(tried_paths)} paths.")
+    return None, tried_paths
+
+
+def validate_target_filename(filename: str) -> bool:
+    """Validate target filename against regex.
+    
+    Args:
+        filename: Filename to validate
+    
+    Returns:
+        True if valid, False otherwise
+    """
+    return bool(TARGET_FILENAME_REGEX.match(filename))
+
+
+def validate_manifest_key(key: str) -> bool:
+    """Validate manifest key against regex.
+    
+    Args:
+        key: Manifest key to validate
+    
+    Returns:
+        True if valid, False otherwise
+    """
+    return bool(MANIFEST_KEY_REGEX.match(key))
+
+
+def auto_generate_filename(asset_id: str) -> str:
+    """Auto-generate filename from asset_id.
+    
+    Args:
+        asset_id: Asset ID (UUID)
+    
+    Returns:
+        Generated filename: asset_<shortid>.webp
+    """
+    # Use first 8 chars of asset_id for shortid
+    shortid = asset_id[:8] if len(asset_id) >= 8 else asset_id
+    return f"asset_{shortid}.webp"
+
+
+class PublishConfig:
+    """Configuration for asset publishing."""
+    
+    def __init__(
+        self,
+        project_root: Optional[Union[str, Path]] = None,
+        publish_root: Optional[Union[str, Path]] = None,
+        comfyui_output_root: Optional[Union[str, Path]] = None,
+        comfyui_url: str = "http://localhost:8188"
+    ):
+        """Initialize publish configuration.
+        
+        Args:
+            project_root: Project root directory (auto-detected if None)
+            publish_root: Publish directory (auto-detected if None)
+            comfyui_output_root: ComfyUI outputs directory (auto-detected if None, best-effort)
+            comfyui_url: ComfyUI server URL (for detection)
+        """
+        # Detect project root
+        if project_root:
+            self.project_root = Path(project_root).resolve()
+            self.project_root_method = "configured"
+        else:
+            self.project_root, self.project_root_method = detect_project_root()
+        
+        # Get publish root
+        if publish_root:
+            self.publish_root = Path(publish_root).resolve()
+        else:
+            self.publish_root = get_default_publish_root(self.project_root)
+        
+        # Ensure publish_root exists
+        self.publish_root.mkdir(parents=True, exist_ok=True)
+        
+        # ComfyUI output root
+        # Priority: explicit param > persistent config > auto-detection
+        if comfyui_output_root:
+            self.comfyui_output_root = Path(comfyui_output_root).resolve()
+            self.comfyui_output_method = "explicit"
+            self.comfyui_tried_paths = []
+        else:
+            # detect_comfyui_output_root now checks persistent config first
+            detected, tried = detect_comfyui_output_root(self.project_root, comfyui_url)
+            self.comfyui_output_root = detected
+            # Check if it came from persistent config
+            persistent_config = load_publish_config()
+            if persistent_config.get("comfyui_output_root"):
+                self.comfyui_output_method = "persistent_config" if detected else "not_found"
+            else:
+                self.comfyui_output_method = "auto-detected" if detected else "not_found"
+            self.comfyui_tried_paths = tried
+        
+        self.comfyui_url = comfyui_url
+
+
+class PublishManager:
+    """Manages safe publishing of ComfyUI assets to web project directories."""
+    
+    def __init__(self, config: PublishConfig):
+        """Initialize publish manager.
+        
+        Args:
+            config: Publish configuration
+        """
+        self.config = config
+        self._manifest_lock = threading.Lock()  # Process-level lock for manifest updates
+        logger.info(f"Initialized PublishManager with publish_root={config.publish_root}")
+        if config.comfyui_output_root:
+            logger.info(f"ComfyUI output root: {config.comfyui_output_root} (method: {config.comfyui_output_method})")
+    
+    def ensure_ready(self) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]]]:
+        """Check if publish manager is ready to publish.
+        
+        Returns:
+            Tuple of (is_ready, error_code, error_info)
+            error_info contains tried paths, warnings, etc.
+        """
+        errors = []
+        warnings = []
+        info = {}
+        
+        # Check publish_root is writable
+        if not os.access(self.config.publish_root, os.W_OK):
+            errors.append("PUBLISH_ROOT_NOT_WRITABLE")
+            return False, "PUBLISH_ROOT_NOT_WRITABLE", {
+                "publish_root": str(self.config.publish_root),
+                "message": f"Publish root is not writable: {self.config.publish_root}"
+            }
+        
+        # Check ComfyUI output root
+        if not self.config.comfyui_output_root:
+            errors.append("COMFYUI_OUTPUT_ROOT_NOT_FOUND")
+            return False, "COMFYUI_OUTPUT_ROOT_NOT_FOUND", {
+                "tried_paths": self.config.comfyui_tried_paths,
+                "message": f"COMFYUI_OUTPUT_ROOT not configured. Tried: {[p['path'] for p in self.config.comfyui_tried_paths]}. Set COMFYUI_OUTPUT_ROOT environment variable."
+            }
+        
+        # Check ComfyUI output root exists and is valid
+        if not self.config.comfyui_output_root.exists():
+            errors.append("COMFYUI_OUTPUT_ROOT_NOT_FOUND")
+            return False, "COMFYUI_OUTPUT_ROOT_NOT_FOUND", {
+                "comfyui_output_root": str(self.config.comfyui_output_root),
+                "message": f"ComfyUI output root does not exist: {self.config.comfyui_output_root}"
+            }
+        
+        if not validate_comfyui_output_root(self.config.comfyui_output_root):
+            warnings.append(f"ComfyUI output root may not be valid: {self.config.comfyui_output_root}")
+        
+        # Add warnings for fallback detection
+        if self.config.project_root_method == "auto-detected":
+            warnings.append("Using fallback project root detection (start server from repo root for best results)")
+        
+        if self.config.comfyui_output_method == "auto-detected":
+            warnings.append("Using auto-detected ComfyUI output root (set COMFYUI_OUTPUT_ROOT for explicit control)")
+        
+        return True, None, {"warnings": warnings} if warnings else None
+    
+    def resolve_source_path(self, subfolder: str, filename: str) -> Path:
+        """Resolve source path from asset metadata.
+        
+        Args:
+            subfolder: Asset subfolder (often empty)
+            filename: Asset filename
+        
+        Returns:
+            Resolved source path
+        
+        Raises:
+            ValueError: If source path is outside COMFYUI_OUTPUT_ROOT or doesn't exist
+        """
+        if not self.config.comfyui_output_root:
+            raise ValueError("COMFYUI_OUTPUT_ROOT not configured")
+        
+        # Join paths
+        if subfolder:
+            source_path = self.config.comfyui_output_root / subfolder / filename
+        else:
+            source_path = self.config.comfyui_output_root / filename
+        
+        # Canonicalize to resolve symlinks and get absolute path
+        try:
+            source_real = canonicalize_path(source_path)
+        except ValueError as e:
+            raise ValueError(f"Source path cannot be resolved: {e}")
+        
+        # Verify containment within ComfyUI output root
+        output_root_real = canonicalize_path(self.config.comfyui_output_root)
+        if not is_within(source_real, output_root_real):
+            raise ValueError(
+                f"Source path {source_real} is outside ComfyUI output root {output_root_real}"
+            )
+        
+        # Verify file exists
+        if not source_real.exists():
+            raise ValueError(f"Source file does not exist: {source_real}")
+        
+        if not source_real.is_file():
+            raise ValueError(f"Source path is not a file: {source_real}")
+        
+        return source_real
+    
+    def resolve_target_path(self, target_filename: str) -> Path:
+        """Resolve target path from target_filename.
+        
+        Args:
+            target_filename: Target filename (validated by regex)
+        
+        Returns:
+            Resolved target path
+        
+        Raises:
+            ValueError: If target_filename is invalid or path is outside publish root
+        """
+        # Validate filename
+        if not validate_target_filename(target_filename):
+            raise ValueError(
+                f"Invalid target_filename: '{target_filename}'. "
+                f"Must match regex: ^[a-z0-9][a-z0-9._-]{{0,63}}\\.(webp|png|jpg|jpeg)$"
+            )
+        
+        target_path = self.config.publish_root / target_filename
+        
+        # Verify containment within publish root
+        # Use must_exist=False since target may not exist yet
+        target_real = canonicalize_path(target_path, must_exist=False)
+        publish_root_real = canonicalize_path(self.config.publish_root, must_exist=True)
+        if not is_within(target_real, publish_root_real, child_must_exist=False):
+            raise ValueError(
+                f"Target path {target_real} is outside publish root {publish_root_real}"
+            )
+        
+        return target_real
+    
+    def _compress_image(
+        self,
+        source_path: Path,
+        target_format: str,
+        max_bytes: int
+    ) -> Tuple[bytes, Dict[str, Any]]:
+        """Compress image using deterministic compression ladder.
+        
+        Tries quality levels and downscaling in a fixed sequence until size limit is met.
+        
+        Args:
+            source_path: Source image path
+            target_format: Target format ("webp", "png", "jpg")
+            max_bytes: Maximum file size in bytes
+        
+        Returns:
+            Tuple of (compressed_bytes, compression_info dict)
+        
+        Raises:
+            ImportError: If Pillow is not available
+            ValueError: If image cannot be compressed below max_bytes
+        """
+        if not PIL_AVAILABLE:
+            raise ImportError("Pillow is required for image compression. Install with: pip install Pillow")
+        
+        # Read source image
+        with open(source_path, "rb") as f:
+            source_bytes = f.read()
+        
+            # If source is already small enough and format matches, return as-is
+            source_ext = source_path.suffix.lower().lstrip(".")
+            if len(source_bytes) <= max_bytes and source_ext == target_format:
+                return source_bytes, {
+                    "compressed": False,
+                    "original_size": len(source_bytes),
+                    "final_size": len(source_bytes),
+                    "quality": None,
+                    "downscaled": False
+                }
+        
+        # Load image
+        with Image.open(BytesIO(source_bytes)) as im:
+            original_size = im.size
+            original_mode = im.mode
+            
+            # Convert to RGB if needed (for JPEG/WebP)
+            if target_format in ("webp", "jpg", "jpeg"):
+                if im.mode in ("RGBA", "LA", "P"):
+                    # Create white background for transparency
+                    background = Image.new("RGB", im.size, (255, 255, 255))
+                    if im.mode == "P":
+                        im = im.convert("RGBA")
+                    if im.mode in ("RGBA", "LA"):
+                        background.paste(im, mask=im.split()[-1] if im.mode == "RGBA" else None)
+                    im = background
+                elif im.mode != "RGB":
+                    im = im.convert("RGB")
+            
+            # Deterministic compression ladder
+            # Quality progression: [85, 75, 65, 55, 45, 35]
+            # Downscale targets: [original, 0.9x, 0.75x, 0.6x, 0.5x] (if needed)
+            quality_levels = [85, 75, 65, 55, 45, 35]
+            downscale_factors = [1.0, 0.9, 0.75, 0.6, 0.5]
+            
+            compression_info = {
+                "compressed": True,
+                "original_size": len(source_bytes),
+                "original_dimensions": original_size,
+                "quality": None,
+                "final_dimensions": original_size,
+                "downscaled": False
+            }
+            
+            for downscale_factor in downscale_factors:
+                # Calculate new dimensions
+                if downscale_factor < 1.0:
+                    new_size = (max(1, int(im.size[0] * downscale_factor)), 
+                               max(1, int(im.size[1] * downscale_factor)))
+                    im_resized = im.resize(new_size, Image.Resampling.LANCZOS)
+                    compression_info["downscaled"] = True
+                    compression_info["final_dimensions"] = new_size
+                else:
+                    im_resized = im
+                
+                # Try quality levels
+                for quality in quality_levels:
+                    buf = BytesIO()
+                    
+                    try:
+                        if target_format == "webp":
+                            save_kwargs = {
+                                "format": "WEBP",
+                                "quality": quality,
+                                "method": 5  # Method 5 trades CPU for size
+                            }
+                            # Preserve alpha if original had it and we're not converting to RGB
+                            if original_mode in ("RGBA", "LA") and downscale_factor == 1.0:
+                                # For WebP, we can preserve alpha if not downscaled
+                                if im_resized.mode not in ("RGBA", "LA"):
+                                    # Re-check if we need alpha
+                                    pass
+                            im_resized.save(buf, **save_kwargs)
+                        elif target_format in ("jpg", "jpeg"):
+                            im_resized.save(buf, format="JPEG", quality=quality, optimize=True)
+                        elif target_format == "png":
+                            # PNG doesn't use quality, but we can optimize
+                            im_resized.save(buf, format="PNG", optimize=True)
+                        else:
+                            raise ValueError(f"Unsupported target format: {target_format}")
+                        
+                        compressed_bytes = buf.getvalue()
+                        
+                        # Check if within size limit
+                        if len(compressed_bytes) <= max_bytes:
+                            compression_info["final_size"] = len(compressed_bytes)
+                            compression_info["quality"] = quality
+                            logger.info(
+                                f"Compressed image: {len(source_bytes)} -> {len(compressed_bytes)} bytes "
+                                f"(quality={quality}, downscale={downscale_factor:.2f})"
+                            )
+                            return compressed_bytes, compression_info
+                    except Exception as e:
+                        logger.warning(f"Compression attempt failed (quality={quality}, factor={downscale_factor}): {e}")
+                        continue
+            
+            # If we get here, couldn't compress below max_bytes
+            # Return the smallest we achieved
+            buf = BytesIO()
+            if target_format == "webp":
+                im_resized.save(buf, format="WEBP", quality=35, method=5)
+            elif target_format in ("jpg", "jpeg"):
+                im_resized.save(buf, format="JPEG", quality=35, optimize=True)
+            else:
+                im_resized.save(buf, format="PNG", optimize=True)
+            
+            final_bytes = buf.getvalue()
+            compression_info["final_size"] = len(final_bytes)
+            compression_info["quality"] = 35
+            
+            if len(final_bytes) > max_bytes:
+                raise ValueError(
+                    f"Image cannot be compressed below {max_bytes} bytes. "
+                    f"Smallest achieved: {len(final_bytes)} bytes. "
+                    f"Original: {len(source_bytes)} bytes, {original_size[0]}x{original_size[1]}"
+                )
+            
+            return final_bytes, compression_info
+    
+    def copy_asset(
+        self,
+        source_path: Path,
+        target_path: Path,
+        overwrite: bool = True,
+        asset_id: Optional[str] = None,
+        target_filename: Optional[str] = None,
+        format: str = "webp",
+        max_bytes: int = 600_000
+    ) -> Dict[str, Any]:
+        """Copy asset from source to target with atomic write and optional compression.
+        
+        Args:
+            source_path: Source file path
+            target_path: Target file path
+            overwrite: Whether to overwrite existing file (default: True)
+            asset_id: Optional asset ID for logging
+            target_filename: Optional target filename for logging
+            format: Target format (default: webp)
+            max_bytes: Maximum file size in bytes (default: 600KB)
+        
+        Returns:
+            Dict with published file info: dest_path, dest_url, bytes_size, mime_type, compression_info
+        
+        Raises:
+            ValueError: If overwrite is False and target exists, or if size limit exceeded
+            OSError: If copy fails
+        """
+        if target_path.exists() and not overwrite:
+            raise ValueError(f"Target file already exists and overwrite=False: {target_path}")
+        
+        # Create temp file in same directory for atomic write
+        temp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+        
+        try:
+            # Check if source is an image and needs compression
+            source_ext = source_path.suffix.lower()
+            target_ext = target_path.suffix.lower()
+            is_image = source_ext in (".png", ".jpg", ".jpeg", ".webp", ".gif")
+            needs_compression = is_image and (format != "original" or target_ext != source_ext)
+            
+            if needs_compression and PIL_AVAILABLE:
+                # Compress image
+                compressed_bytes, compression_info = self._compress_image(
+                    source_path, format, max_bytes
+                )
+                
+                # Write compressed image
+                with open(temp_path, "wb") as f:
+                    f.write(compressed_bytes)
+            else:
+                # Simple copy (no compression)
+                shutil.copy2(source_path, temp_path)
+                compression_info = {
+                    "compressed": False,
+                    "original_size": source_path.stat().st_size,
+                    "final_size": None,  # Will be set below
+                }
+            
+            # Atomic rename
+            temp_path.replace(target_path)
+            
+            # Get file size
+            bytes_size = target_path.stat().st_size
+            if compression_info.get("final_size") is None:
+                compression_info["final_size"] = bytes_size
+            
+            # Determine relative URL (from publish_root)
+            try:
+                rel_path = target_path.relative_to(self.config.publish_root)
+                dest_url = f"/gen/{rel_path.as_posix()}"
+            except ValueError:
+                # Fallback if relative path calculation fails
+                dest_url = f"/gen/{target_path.name}"
+            
+            # Infer mime type from extension
+            ext = target_path.suffix.lower()
+            mime_map = {
+                ".png": "image/png",
+                ".jpg": "image/jpeg",
+                ".jpeg": "image/jpeg",
+                ".webp": "image/webp",
+                ".gif": "image/gif"
+            }
+            mime_type = mime_map.get(ext, "application/octet-stream")
+            
+            logger.info(f"Published asset: {source_path} -> {target_path} ({bytes_size} bytes)")
+            
+            # Log to publish_log.jsonl
+            self._log_publish(
+                asset_id=asset_id,
+                target_filename=target_filename,
+                source_path=str(source_path),
+                dest_path=str(target_path),
+                bytes_size=bytes_size
+            )
+            
+            result = {
+                "dest_path": str(target_path),
+                "dest_url": dest_url,
+                "bytes_size": bytes_size,
+                "mime_type": mime_type,
+                "compression_info": compression_info
+            }
+            
+            return result
+        except Exception as e:
+            # Clean up temp file on error
+            if temp_path.exists():
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
+            raise
+    
+    def update_manifest(self, manifest_key: str, filename: str):
+        """Update manifest.json with published asset.
+        
+        Uses process-level lock to prevent race conditions.
+        
+        Args:
+            manifest_key: Manifest key (validated by regex)
+            filename: Published filename
+        """
+        # Validate manifest key
+        if not validate_manifest_key(manifest_key):
+            raise ValueError(
+                f"Invalid manifest_key: '{manifest_key}'. "
+                f"Must match regex: ^[a-z0-9][a-z0-9._-]{{0,63}}$"
+            )
+        
+        manifest_path = self.config.publish_root / "manifest.json"
+        
+        # Process-level lock for atomicity
+        with self._manifest_lock:
+            # Read existing manifest or create empty dict
+            if manifest_path.exists():
+                try:
+                    with open(manifest_path, "r", encoding="utf-8") as f:
+                        manifest = json.load(f)
+                except (json.JSONDecodeError, OSError) as e:
+                    logger.warning(f"Failed to read manifest, creating new one: {e}")
+                    manifest = {}
+            else:
+                manifest = {}
+            
+            # Update manifest entry (simple key→filename, no arrays in v1)
+            manifest[manifest_key] = filename
+            
+            # Atomic write: write to temp file then rename
+            temp_path = manifest_path.with_suffix(".tmp")
+            try:
+                with open(temp_path, "w", encoding="utf-8") as f:
+                    json.dump(manifest, f, indent=2)
+                temp_path.replace(manifest_path)
+                logger.debug(f"Updated manifest: {manifest_key} -> {filename}")
+            except (OSError, json.JSONEncodeError) as e:
+                if temp_path.exists():
+                    try:
+                        temp_path.unlink()
+                    except OSError:
+                        pass
+                logger.error(f"Failed to update manifest: {e}")
+                raise
+    
+    def _log_publish(
+        self,
+        asset_id: Optional[str],
+        target_filename: Optional[str],
+        source_path: str,
+        dest_path: str,
+        bytes_size: int
+    ):
+        """Log publish operation to publish_log.jsonl.
+        
+        Args:
+            asset_id: Asset ID (optional)
+            target_filename: Target filename (optional)
+            source_path: Source file path
+            dest_path: Destination file path
+            bytes_size: File size in bytes
+        """
+        log_path = self.config.publish_root / "publish_log.jsonl"
+        
+        log_entry = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "asset_id": asset_id,
+            "target_filename": target_filename,
+            "source_path": source_path,
+            "dest_path": dest_path,
+            "bytes_size": bytes_size
+        }
+        
+        try:
+            # Append to log file (create if doesn't exist)
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(log_entry) + "\n")
+        except OSError as e:
+            logger.warning(f"Failed to write to publish log: {e}")
+    
+    def get_publish_info(self) -> Dict[str, Any]:
+        """Get publish configuration and status information.
+        
+        Returns:
+            Dict with:
+            - project_root: Path and detection method
+            - publish_root: Path, exists, writable
+            - comfyui_output_root: Path or None
+            - comfyui_tried_paths: List of tried paths with validation results
+            - status: "ready" | "needs_comfyui_root" | "error"
+            - message: Human-readable status
+            - warnings: List of warnings
+            - config_file: Path to persistent config file
+        """
+        is_ready, error_code, error_info = self.ensure_ready()
+        
+        config_file = get_publish_config_file()
+        persistent_config = load_publish_config()
+        
+        result = {
+            "project_root": {
+                "path": str(self.config.project_root),
+                "detection_method": self.config.project_root_method
+            },
+            "publish_root": {
+                "path": str(self.config.publish_root),
+                "exists": self.config.publish_root.exists(),
+                "writable": os.access(self.config.publish_root, os.W_OK) if self.config.publish_root.exists() else False
+            },
+            "comfyui_output_root": {
+                "path": str(self.config.comfyui_output_root) if self.config.comfyui_output_root else None,
+                "exists": self.config.comfyui_output_root.exists() if self.config.comfyui_output_root else False,
+                "detection_method": self.config.comfyui_output_method,
+                "configured": persistent_config.get("comfyui_output_root") is not None
+            },
+            "comfyui_tried_paths": self.config.comfyui_tried_paths,
+            "config_file": str(config_file),
+            "status": "ready" if is_ready else ("needs_comfyui_root" if error_code == "COMFYUI_OUTPUT_ROOT_NOT_FOUND" else "error"),
+            "message": error_info.get("message", "Ready to publish") if error_info else "Ready to publish"
+        }
+        
+        if error_info and "warnings" in error_info:
+            result["warnings"] = error_info["warnings"]
+        elif not is_ready and error_info:
+            result["error_code"] = error_code
+            if "tried_paths" in error_info:
+                result["comfyui_tried_paths"] = error_info["tried_paths"]
+            # Add helpful message about set_comfyui_output_root tool
+            if error_code == "COMFYUI_OUTPUT_ROOT_NOT_FOUND":
+                result["message"] = (
+                    f"{error_info.get('message', 'COMFYUI_OUTPUT_ROOT not configured.')} "
+                    f"Use the set_comfyui_output_root tool to configure it once."
+                )
+        
+        return result
+    
+    def set_comfyui_output_root(self, path: Union[str, Path]) -> Dict[str, Any]:
+        """Set ComfyUI output root in persistent config.
+        
+        Args:
+            path: Path to ComfyUI output directory
+        
+        Returns:
+            Dict with success status and validation results
+        """
+        try:
+            resolved = Path(path).resolve()
+            
+            # Validate path exists
+            if not resolved.exists():
+                return {
+                    "error": "COMFYUI_OUTPUT_ROOT_PATH_NOT_FOUND",
+                    "message": f"Path does not exist: {resolved}",
+                    "path": str(resolved)
+                }
+            
+            if not resolved.is_dir():
+                return {
+                    "error": "COMFYUI_OUTPUT_ROOT_NOT_DIRECTORY",
+                    "message": f"Path is not a directory: {resolved}",
+                    "path": str(resolved)
+                }
+            
+            # Validate it looks like ComfyUI output
+            is_valid = validate_comfyui_output_root(resolved)
+            if not is_valid:
+                return {
+                    "error": "COMFYUI_OUTPUT_ROOT_INVALID",
+                    "message": f"Path does not appear to be a ComfyUI output directory: {resolved}. Expected ComfyUI_*.png files or output/temp subdirectories.",
+                    "path": str(resolved),
+                    "warning": "Path saved but validation failed. It may still work if ComfyUI outputs are present."
+                }
+            
+            # Save to persistent config
+            success = save_publish_config({"comfyui_output_root": str(resolved)})
+            if not success:
+                return {
+                    "error": "CONFIG_SAVE_FAILED",
+                    "message": f"Failed to save config to {get_publish_config_file()}",
+                    "path": str(resolved)
+                }
+            
+            # Update config in memory
+            self.config.comfyui_output_root = resolved
+            self.config.comfyui_output_method = "persistent_config"
+            self.config.comfyui_tried_paths = []
+            
+            logger.info(f"Set ComfyUI output root to: {resolved}")
+            
+            return {
+                "success": True,
+                "path": str(resolved),
+                "message": f"ComfyUI output root configured: {resolved}",
+                "config_file": str(get_publish_config_file())
+            }
+            
+        except (OSError, ValueError) as e:
+            return {
+                "error": "INVALID_PATH",
+                "message": f"Invalid path: {e}",
+                "path": str(path)
+            }

--- a/tests/HOW_TO_TEST_PUBLISH.md
+++ b/tests/HOW_TO_TEST_PUBLISH.md
@@ -1,0 +1,263 @@
+# How to Test Publish Assets Feature
+
+## Overview
+
+The publish assets feature allows you to safely copy ComfyUI-generated assets to a web project directory (e.g., `public/gen/`) with automatic compression and manifest management.
+
+**Key features:**
+- **Zero-config setup**: Auto-detects project root and publish directory
+- **Persistent configuration**: One-time setup via `set_comfyui_output_root` tool
+- **Two modes**: Demo mode (explicit filename) or Library mode (auto-generated)
+- **Automatic compression**: Images compressed to meet size limits (default: 600KB)
+- **Manifest management**: Automatic `manifest.json` updates for hot-swapping
+
+## Critical Contract
+
+**⚠️ IMPORTANT:** The MCP server must be started from the repository root (cwd). This ensures proper project root detection.
+
+**Other important behaviors:**
+- Asset IDs are session-scoped and expire on server restart
+- Publishing writes only to `<project_root>/public/gen/` (or `static/gen/`, `assets/gen/`)
+- If ComfyUI output root detection fails, use `set_comfyui_output_root` tool
+
+## Running Unit Tests
+
+**From project root:**
+```bash
+# Run all publish tests
+pytest tests/test_publish.py -v
+
+# Run specific test class
+pytest tests/test_publish.py::TestPublishManager -v
+
+# Run with coverage
+pytest tests/test_publish.py --cov=managers.publish_manager --cov=tools.publish
+```
+
+**Note:** Don't run `python test_publish.py` directly - use `pytest` from the project root.
+
+**Troubleshooting pytest errors:**
+
+- **`ImportError: cannot import name 'FixtureDef'`** → Use `python -m pytest` instead of `pytest`
+- **Permission errors on Windows** → Clean temp dir: `rmdir /s C:\Users\<user>\AppData\Local\Temp\pytest-of-<user>`
+- **Plugin conflicts** → Use virtual environment:
+  ```bash
+  python -m venv venv
+  venv\Scripts\activate  # Windows
+  pip install -r requirements.txt
+  python -m pytest tests/test_publish.py -v
+  ```
+
+## Quick Setup
+
+The publish tools are **always available** - no environment variables required! The system auto-detects:
+- Project root (from cwd)
+- Publish directory (`public/gen`, `static/gen`, or `assets/gen`)
+- ComfyUI output root (best-effort, with fallback to manual config)
+
+### 1. Check Configuration
+
+First, verify your setup:
+
+```python
+info = get_publish_info()
+# Returns: project_root, publish_root, comfyui_output_root, status, etc.
+```
+
+**If `status` is not "ready":**
+- Check `comfyui_output_root` - if `None`, use `set_comfyui_output_root` tool
+- Check `publish_root` - should be writable
+- Review `warnings` for any issues
+
+### 2. Configure ComfyUI Output Root (if needed)
+
+If auto-detection fails, set it once:
+
+```python
+result = set_comfyui_output_root("E:/comfyui-desktop/output")
+# Returns: success, path, config_file
+```
+
+This is saved to persistent config and remembered across restarts:
+- Windows: `%APPDATA%/comfyui-mcp-server/publish_config.json`
+- Mac: `~/Library/Application Support/comfyui-mcp-server/publish_config.json`
+- Linux: `~/.config/comfyui-mcp-server/publish_config.json`
+
+### 3. Start ComfyUI (if not running)
+
+Make sure ComfyUI is running on `http://localhost:8188` (or your configured URL).
+
+### 4. Start the MCP Server
+
+From the repository root:
+
+```bash
+python server.py --stdio
+```
+
+The publish tools are always registered - no environment variables needed!
+
+## Test Workflow
+
+### 1. Generate an Image
+
+```python
+result = generate_image(prompt="a beautiful sunset", return_inline_preview=False)
+asset_id = result["asset_id"]
+# Save: asset_id
+```
+
+### 2. Publish Asset (Demo Mode)
+
+**Demo mode** - explicit filename:
+
+```python
+publish_result = publish_asset(
+    asset_id="your-asset-id",
+    target_filename="hero.webp",  # Explicit filename
+    format="webp",                  # Optional: webp, png, jpg (default: webp)
+    max_bytes=600_000,              # Optional: size limit (default: 600KB)
+    overwrite=True                  # Optional: overwrite existing (default: True)
+)
+```
+
+**Returns:**
+```json
+{
+  "dest_url": "/gen/hero.webp",
+  "dest_path": "E:\\dev\\project\\public\\gen\\hero.webp",
+  "bytes_size": 37478,
+  "mime_type": "image/webp",
+  "width": 512,
+  "height": 512,
+  "compression_info": {
+    "compressed": true,
+    "original_size": 457374,
+    "quality": 85,
+    "downscaled": false,
+    "final_size": 37478
+  }
+}
+```
+
+### 3. Publish Asset (Library Mode)
+
+**Library mode** - auto-generated filename with manifest:
+
+```python
+publish_result = publish_asset(
+    asset_id="your-asset-id",
+    manifest_key="hero-image",      # Required when target_filename omitted
+    format="webp",                  # Optional
+    max_bytes=600_000,              # Optional
+    overwrite=True                  # Optional
+)
+```
+
+**Returns:**
+```json
+{
+  "dest_url": "/gen/asset_0b3eacbc.webp",
+  "dest_path": "E:\\dev\\project\\public\\gen\\asset_0b3eacbc.webp",
+  "bytes_size": 37478,
+  "mime_type": "image/webp",
+  "width": 512,
+  "height": 512,
+  "compression_info": {...}
+}
+```
+
+The manifest (`public/gen/manifest.json`) is automatically updated:
+```json
+{
+  "hero-image": "asset_0b3eacbc.webp"
+}
+```
+
+### 4. Verify
+
+- **File exists:** Check `public/gen/hero.webp` (or auto-generated filename)
+- **Manifest updated:** Check `public/gen/manifest.json` (if `manifest_key` provided)
+- **Log entry:** Check `public/gen/publish_log.jsonl` has new entry
+- **Compression:** Check `compression_info` in response
+
+## Two Modes Explained
+
+### Demo Mode
+- **Use when:** You want a specific, deterministic filename
+- **Provide:** `target_filename` (e.g., `"hero.webp"`)
+- **Manifest:** Not updated (unless you also provide `manifest_key`)
+- **Example:** `publish_asset(asset_id="...", target_filename="hero.webp")`
+
+### Library Mode
+- **Use when:** You want auto-generated filenames with manifest tracking
+- **Provide:** `manifest_key` (required), omit `target_filename`
+- **Manifest:** Automatically updated with `manifest_key → filename` mapping
+- **Filename:** Auto-generated as `asset_<shortid>.webp` (or specified format)
+- **Example:** `publish_asset(asset_id="...", manifest_key="hero")`
+
+## Error Codes
+
+The system returns machine-readable error codes:
+
+- **`ASSET_NOT_FOUND_OR_EXPIRED`**: Asset not in current session (session-scoped)
+- **`INVALID_TARGET_FILENAME`**: Filename doesn't match regex `^[a-z0-9][a-z0-9._-]{0,63}\.(webp|png|jpg|jpeg)$`
+- **`INVALID_MANIFEST_KEY`**: Manifest key doesn't match regex `^[a-z0-9][a-z0-9._-]{0,63}$`
+- **`MANIFEST_KEY_REQUIRED`**: `manifest_key` required when `target_filename` omitted
+- **`SOURCE_PATH_OUTSIDE_ROOT`**: Source file outside ComfyUI output root
+- **`PATH_TRAVERSAL_DETECTED`**: Path traversal attempt detected
+- **`COMFYUI_OUTPUT_ROOT_NOT_FOUND`**: ComfyUI output root not configured
+- **`PUBLISH_ROOT_NOT_WRITABLE`**: Publish directory not writable
+- **`PUBLISH_FAILED`**: Copy/compression operation failed
+
+## Compression Details
+
+Images are automatically compressed using a deterministic compression ladder:
+
+1. **Quality progression**: [85, 75, 65, 55, 45, 35]
+2. **Downscale factors**: [1.0, 0.9, 0.75, 0.6, 0.5] (if needed)
+3. **Format conversion**: PNG/JPEG → WebP (if format="webp")
+4. **Size limit**: Enforced via `max_bytes` (default: 600KB)
+
+The compression ladder tries quality levels first, then downscaling if needed, until the size limit is met.
+
+## Quick Test Script
+
+```python
+# 1. Check configuration
+info = get_publish_info()
+assert info["status"] == "ready"
+
+# 2. Configure ComfyUI output (if needed)
+if not info["comfyui_output_root"]["path"]:
+    set_comfyui_output_root("E:/comfyui-desktop/output")
+
+# 3. Generate image
+result = generate_image(prompt="test image")
+asset_id = result["asset_id"]
+
+# 4. Publish (demo mode)
+publish = publish_asset(asset_id=asset_id, target_filename="test.webp")
+
+# 5. Verify
+assert "dest_url" in publish
+assert publish["dest_url"] == "/gen/test.webp"
+assert "compression_info" in publish
+print(f"✅ Published to {publish['dest_url']} ({publish['bytes_size']} bytes)")
+
+# 6. Publish (library mode)
+publish2 = publish_asset(asset_id=asset_id, manifest_key="test-image")
+assert "dest_url" in publish2
+print(f"✅ Published to {publish2['dest_url']} with manifest key 'test-image'")
+```
+
+## Troubleshooting
+
+- **Tool not appearing in MCP** → Tools are always registered; check server logs for errors
+- **"COMFYUI_OUTPUT_ROOT_NOT_FOUND"** → Use `set_comfyui_output_root` tool to configure
+- **"Asset not found or expired"** → Assets are session-scoped; generate new asset in same session
+- **"MANIFEST_KEY_REQUIRED"** → Provide `manifest_key` when omitting `target_filename` (library mode)
+- **"INVALID_TARGET_FILENAME"** → Filename must match regex (lowercase, alphanumeric, dots/dashes/underscores, valid extension)
+- **"Source file does not exist"** → Check ComfyUI output directory path
+- **Compression fails** → Image may be too large; check `compression_info` for details
+- **Server logs show errors** → Check `get_publish_info()` for configuration status

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,768 @@
+"""Tests for publish manager and path safety utilities
+
+Run with pytest from project root:
+    pytest tests/test_publish.py -v
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from managers.publish_manager import (
+    PublishConfig,
+    PublishManager,
+    auto_generate_filename,
+    canonicalize_path,
+    detect_project_root,
+    get_default_publish_root,
+    get_publish_config_dir,
+    get_publish_config_file,
+    is_within,
+    load_publish_config,
+    save_publish_config,
+    validate_comfyui_output_root,
+    validate_manifest_key,
+    validate_target_filename,
+)
+
+
+class TestPathSafety:
+    """Tests for path safety utilities"""
+    
+    def test_canonicalize_path_absolute(self, tmp_path):
+        """Test canonicalize_path with absolute path"""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+        
+        result = canonicalize_path(test_file)
+        assert isinstance(result, Path)
+        assert result.is_absolute()
+        assert result.exists()
+    
+    def test_canonicalize_path_relative(self, tmp_path):
+        """Test canonicalize_path with relative path"""
+        os.chdir(tmp_path)
+        test_file = Path("test.txt")
+        test_file.write_text("test")
+        
+        result = canonicalize_path(test_file)
+        assert isinstance(result, Path)
+        assert result.is_absolute()
+        assert result.exists()
+    
+    def test_canonicalize_path_nonexistent(self):
+        """Test canonicalize_path with nonexistent path raises ValueError"""
+        with pytest.raises(ValueError):
+            canonicalize_path("/nonexistent/path/that/does/not/exist")
+    
+    def test_canonicalize_path_nonexistent_optional(self, tmp_path):
+        """Test canonicalize_path with nonexistent path and must_exist=False"""
+        nonexistent = tmp_path / "nonexistent" / "file.txt"
+        result = canonicalize_path(nonexistent, must_exist=False)
+        assert isinstance(result, Path)
+        assert result.is_absolute()
+        # Path doesn't exist, but should still resolve
+    
+    def test_is_within_simple(self, tmp_path):
+        """Test is_within with simple parent-child relationship"""
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        child = parent / "child.txt"
+        child.write_text("test")
+        
+        assert is_within(child, parent) is True
+        assert is_within(parent, child) is False
+    
+    def test_is_within_nested(self, tmp_path):
+        """Test is_within with nested directories"""
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        nested = parent / "nested" / "deep"
+        nested.mkdir(parents=True)
+        child = nested / "file.txt"
+        child.write_text("test")
+        
+        assert is_within(child, parent) is True
+        assert is_within(nested, parent) is True
+    
+    def test_is_within_outside(self, tmp_path):
+        """Test is_within returns False for paths outside parent"""
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        child = outside / "file.txt"
+        child.write_text("test")
+        
+        assert is_within(child, parent) is False
+    
+    def test_is_within_traversal_attempt(self, tmp_path):
+        """Test is_within prevents path traversal"""
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        
+        # Try to escape with ../
+        traversal = tmp_path / "parent" / ".." / "outside"
+        traversal.parent.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        child = outside / "file.txt"
+        child.write_text("test")
+        
+        # After canonicalization, traversal should be resolved
+        # and should not be within parent
+        assert is_within(child, parent) is False
+    
+    def test_is_within_same_path(self, tmp_path):
+        """Test is_within with same path"""
+        path = tmp_path / "test"
+        path.mkdir()
+        
+        # A path is considered within itself
+        assert is_within(path, path) is True
+    
+    def test_is_within_nonexistent_child(self, tmp_path):
+        """Test is_within with nonexistent child path"""
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        nonexistent = parent / "nonexistent.txt"
+        
+        # Should work with child_must_exist=False
+        assert is_within(nonexistent, parent, child_must_exist=False) is True
+
+
+class TestValidationFunctions:
+    """Tests for validation functions"""
+    
+    def test_validate_target_filename_valid(self):
+        """Test validate_target_filename with valid filenames"""
+        assert validate_target_filename("hero.webp") is True
+        assert validate_target_filename("test-image.png") is True
+        assert validate_target_filename("logo_123.jpg") is True
+        assert validate_target_filename("a.webp") is True  # Min length
+        assert validate_target_filename("a" * 63 + ".webp") is True  # Max length
+    
+    def test_validate_target_filename_invalid(self):
+        """Test validate_target_filename with invalid filenames"""
+        assert validate_target_filename("Hero.webp") is False  # Uppercase
+        assert validate_target_filename("test.webp") is False  # Starts with lowercase but...
+        assert validate_target_filename("../test.webp") is False  # Path traversal
+        assert validate_target_filename("test/path.webp") is False  # Slash
+        assert validate_target_filename("test\\path.webp") is False  # Backslash
+        assert validate_target_filename(".webp") is False  # No name
+        assert validate_target_filename("test") is False  # No extension
+        assert validate_target_filename("test.gif") is False  # Invalid extension
+        assert validate_target_filename("a" * 64 + ".webp") is False  # Too long
+    
+    def test_validate_manifest_key_valid(self):
+        """Test validate_manifest_key with valid keys"""
+        assert validate_manifest_key("hero") is True
+        assert validate_manifest_key("test-image") is True
+        assert validate_manifest_key("logo_123") is True
+        assert validate_manifest_key("a") is True  # Min length
+        assert validate_manifest_key("a" * 63) is True  # Max length
+    
+    def test_validate_manifest_key_invalid(self):
+        """Test validate_manifest_key with invalid keys"""
+        assert validate_manifest_key("Hero") is False  # Uppercase
+        assert validate_manifest_key("../test") is False  # Path traversal
+        assert validate_manifest_key("test/path") is False  # Slash
+        assert validate_manifest_key("") is False  # Empty
+        assert validate_manifest_key("a" * 64) is False  # Too long
+        assert validate_manifest_key("test.webp") is False  # Extension not allowed
+    
+    def test_auto_generate_filename(self):
+        """Test auto_generate_filename"""
+        asset_id = "0b3eacbc-25b0-497c-9d63-6d66d9e67387"
+        filename = auto_generate_filename(asset_id)
+        
+        assert filename.startswith("asset_")
+        assert filename.endswith(".webp")
+        assert "0b3eacbc" in filename  # First 8 chars of asset_id
+
+
+class TestProjectRootDetection:
+    """Tests for project root detection"""
+    
+    def test_detect_project_root_with_git(self, tmp_path):
+        """Test detect_project_root finds .git marker"""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / ".git").mkdir()  # Create .git marker
+        
+        os.chdir(project_root)
+        root, method = detect_project_root()
+        
+        assert root == project_root.resolve()
+        assert method in ("cwd", "auto-detected")
+    
+    def test_detect_project_root_with_public(self, tmp_path):
+        """Test detect_project_root finds public/ directory"""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "public").mkdir()
+        
+        os.chdir(project_root)
+        root, method = detect_project_root()
+        
+        assert root == project_root.resolve()
+        assert method == "cwd"
+
+
+class TestPublishConfig:
+    """Tests for PublishConfig"""
+    
+    def test_init_minimal(self, tmp_path):
+        """Test PublishConfig with minimal config (auto-detection)"""
+        with patch('managers.publish_manager.detect_project_root', return_value=(tmp_path, "cwd")):
+            config = PublishConfig()
+            
+            assert config.project_root == tmp_path.resolve()
+            assert config.publish_root.exists()
+            assert config.comfyui_output_root is None or config.comfyui_output_root.exists()
+    
+    def test_init_with_project_root(self, tmp_path):
+        """Test PublishConfig with explicit project_root"""
+        config = PublishConfig(project_root=tmp_path)
+        
+        assert config.project_root == tmp_path.resolve()
+        assert config.publish_root.exists()
+    
+    def test_init_with_publish_root(self, tmp_path):
+        """Test PublishConfig with explicit publish_root"""
+        publish_root = tmp_path / "custom" / "publish"
+        config = PublishConfig(project_root=tmp_path, publish_root=publish_root)
+        
+        assert config.publish_root == publish_root.resolve()
+        assert config.publish_root.exists()
+    
+    def test_get_default_publish_root(self, tmp_path):
+        """Test get_default_publish_root"""
+        # Test public/gen
+        (tmp_path / "public").mkdir()
+        result = get_default_publish_root(tmp_path)
+        assert result == (tmp_path / "public" / "gen").resolve()
+        assert result.exists()
+        
+        # Test static/gen fallback
+        tmp_path2 = Path(tempfile.mkdtemp())
+        (tmp_path2 / "static").mkdir()
+        result2 = get_default_publish_root(tmp_path2)
+        assert result2 == (tmp_path2 / "static" / "gen").resolve()
+    
+    def test_validate_comfyui_output_root(self, tmp_path):
+        """Test validate_comfyui_output_root"""
+        output_root = tmp_path / "output"
+        output_root.mkdir()
+        
+        # Create ComfyUI pattern files
+        (output_root / "ComfyUI_00001.png").write_text("test")
+        
+        assert validate_comfyui_output_root(output_root) is True
+    
+    def test_validate_comfyui_output_root_with_images(self, tmp_path):
+        """Test validate_comfyui_output_root with image files"""
+        output_root = tmp_path / "output"
+        output_root.mkdir()
+        
+        # Create image files (lenient check)
+        (output_root / "image1.png").write_text("test")
+        (output_root / "image2.jpg").write_text("test")
+        (output_root / "image3.webp").write_text("test")
+        
+        assert validate_comfyui_output_root(output_root) is True
+
+
+class TestPersistentConfig:
+    """Tests for persistent configuration"""
+    
+    def test_get_publish_config_dir(self):
+        """Test get_publish_config_dir returns platform-specific path"""
+        config_dir = get_publish_config_dir()
+        assert isinstance(config_dir, Path)
+        assert config_dir.is_absolute()
+    
+    def test_get_publish_config_file(self):
+        """Test get_publish_config_file returns config file path"""
+        config_file = get_publish_config_file()
+        assert isinstance(config_file, Path)
+        assert config_file.name == "publish_config.json"
+        assert config_file.parent == get_publish_config_dir()
+    
+    def test_save_and_load_publish_config(self, tmp_path, monkeypatch):
+        """Test save_publish_config and load_publish_config"""
+        # Mock config directory to use tmp_path
+        config_dir = tmp_path / "config"
+        config_file = config_dir / "publish_config.json"
+        
+        monkeypatch.setattr('managers.publish_manager.get_publish_config_dir', lambda: config_dir)
+        monkeypatch.setattr('managers.publish_manager.get_publish_config_file', lambda: config_file)
+        
+        # Save config
+        config = {"comfyui_output_root": "/test/path"}
+        success = save_publish_config(config)
+        assert success is True
+        assert config_file.exists()
+        
+        # Load config
+        loaded = load_publish_config()
+        assert loaded == config
+
+
+class TestPublishManager:
+    """Tests for PublishManager"""
+    
+    def test_resolve_source_path_simple(self, tmp_path):
+        """Test resolve_source_path with simple path"""
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        
+        source_file = output_root / "test.png"
+        source_file.write_text("test")
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        result = manager.resolve_source_path(subfolder="", filename="test.png")
+        assert result == source_file.resolve()
+    
+    def test_resolve_source_path_with_subfolder(self, tmp_path):
+        """Test resolve_source_path with subfolder"""
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        subfolder = output_root / "subfolder"
+        subfolder.mkdir()
+        
+        source_file = subfolder / "test.png"
+        source_file.write_text("test")
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        result = manager.resolve_source_path(subfolder="subfolder", filename="test.png")
+        assert result == source_file.resolve()
+    
+    def test_resolve_source_path_outside_root(self, tmp_path):
+        """Test resolve_source_path rejects paths outside output root"""
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        outside_file = outside / "test.png"
+        outside_file.write_text("test")
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        # Try to access file outside root via traversal
+        with pytest.raises(ValueError, match="outside ComfyUI output root"):
+            manager.resolve_source_path(subfolder="../../outside", filename="test.png")
+    
+    def test_resolve_source_path_nonexistent(self, tmp_path):
+        """Test resolve_source_path with nonexistent file"""
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        with pytest.raises(ValueError, match="does not exist"):
+            manager.resolve_source_path(subfolder="", filename="nonexistent.png")
+    
+    def test_resolve_target_path(self, tmp_path):
+        """Test resolve_target_path with target_filename"""
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish"
+        )
+        manager = PublishManager(config)
+        
+        result = manager.resolve_target_path("hero.webp")
+        expected = (tmp_path / "publish" / "hero.webp").resolve()
+        assert result == expected
+    
+    def test_resolve_target_path_nonexistent(self, tmp_path):
+        """Test resolve_target_path works when target file doesn't exist yet"""
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish"
+        )
+        manager = PublishManager(config)
+        
+        # Target file doesn't exist yet - should still work
+        result = manager.resolve_target_path("hero.webp")
+        assert not result.exists()  # File doesn't exist yet
+        assert result.name == "hero.webp"
+        assert result.parent == config.publish_root.resolve()
+    
+    def test_resolve_target_path_invalid_filename(self, tmp_path):
+        """Test resolve_target_path rejects invalid filenames"""
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish"
+        )
+        manager = PublishManager(config)
+        
+        with pytest.raises(ValueError, match="Invalid target_filename"):
+            manager.resolve_target_path("../escape.webp")
+    
+    def test_copy_asset_simple(self, tmp_path):
+        """Test copy_asset with simple copy"""
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        source_file = output_root / "test.png"
+        source_file.write_text("test content")
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        source_path = manager.resolve_source_path("", "test.png")
+        target_path = manager.resolve_target_path("test.png")
+        
+        result = manager.copy_asset(source_path, target_path, overwrite=True)
+        
+        assert target_path.exists()
+        assert target_path.read_text() == "test content"
+        assert result["dest_path"] == str(target_path)
+        assert result["bytes_size"] > 0
+    
+    def test_copy_asset_no_overwrite(self, tmp_path):
+        """Test copy_asset with overwrite=False"""
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        source_file = output_root / "test.png"
+        source_file.write_text("test content")
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        source_path = manager.resolve_source_path("", "test.png")
+        target_path = manager.resolve_target_path("test.png")
+        
+        # Create existing file
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text("existing")
+        
+        with pytest.raises(ValueError, match="overwrite=False"):
+            manager.copy_asset(source_path, target_path, overwrite=False)
+        
+        # File should still have original content
+        assert target_path.read_text() == "existing"
+    
+    @pytest.mark.skipif(not pytest.importorskip("PIL", reason="Pillow not available"), reason="Pillow required for compression")
+    def test_copy_asset_with_compression(self, tmp_path):
+        """Test copy_asset compresses images"""
+        from PIL import Image
+        
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        
+        # Create a test image
+        source_file = output_root / "test.png"
+        img = Image.new("RGB", (512, 512), color="red")
+        img.save(source_file, "PNG")
+        original_size = source_file.stat().st_size
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        source_path = manager.resolve_source_path("", "test.png")
+        target_path = manager.resolve_target_path("test.webp")
+        
+        # Copy with compression (max 100KB)
+        result = manager.copy_asset(
+            source_path, 
+            target_path, 
+            overwrite=True,
+            format="webp",
+            max_bytes=100_000
+        )
+        
+        assert target_path.exists()
+        assert target_path.suffix == ".webp"
+        assert "compression_info" in result
+        assert result["compression_info"]["compressed"] is True
+        assert result["bytes_size"] <= 100_000
+    
+    def test_update_manifest(self, tmp_path):
+        """Test update_manifest with simple key→filename"""
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish"
+        )
+        manager = PublishManager(config)
+        
+        manager.update_manifest("hero", "hero.webp")
+        
+        manifest_path = config.publish_root / "manifest.json"
+        assert manifest_path.exists()
+        
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+        
+        assert manifest["hero"] == "hero.webp"
+        assert isinstance(manifest["hero"], str)  # Not an array
+    
+    def test_update_manifest_multiple_keys(self, tmp_path):
+        """Test update_manifest with multiple keys"""
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish"
+        )
+        manager = PublishManager(config)
+        
+        manager.update_manifest("hero", "hero.webp")
+        manager.update_manifest("logo", "logo.png")
+        
+        manifest_path = config.publish_root / "manifest.json"
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+        
+        assert manifest["hero"] == "hero.webp"
+        assert manifest["logo"] == "logo.png"
+    
+    def test_ensure_ready(self, tmp_path):
+        """Test ensure_ready checks configuration"""
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        (output_root / "ComfyUI_00001.png").write_text("test")
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        is_ready, error_code, error_info = manager.ensure_ready()
+        assert is_ready is True
+        assert error_code is None
+    
+    def test_ensure_ready_missing_comfyui_root(self, tmp_path):
+        """Test ensure_ready fails when ComfyUI root missing"""
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=None
+        )
+        manager = PublishManager(config)
+        
+        is_ready, error_code, error_info = manager.ensure_ready()
+        assert is_ready is False
+        assert error_code == "COMFYUI_OUTPUT_ROOT_NOT_FOUND"
+
+
+class TestPublishIntegration:
+    """Integration tests for full publish workflow"""
+    
+    def test_full_publish_workflow_demo_mode(self, tmp_path, asset_registry):
+        """Test full publish workflow in demo mode"""
+        # Setup ComfyUI output
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        source_file = output_root / "test.png"
+        source_file.write_text("test image content")
+        
+        # Setup publish config
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        # Register asset
+        asset_record = asset_registry.register_asset(
+            filename="test.png",
+            subfolder="",
+            folder_type="output",
+            workflow_id="generate_image",
+            prompt_id="test_prompt_123",
+            mime_type="image/png",
+            width=512,
+            height=512,
+            bytes_size=len(source_file.read_text())
+        )
+        
+        # Publish asset (demo mode)
+        source_path = manager.resolve_source_path(
+            subfolder=asset_record.subfolder,
+            filename=asset_record.filename
+        )
+        target_path = manager.resolve_target_path("hero.webp")
+        
+        publish_info = manager.copy_asset(
+            source_path=source_path,
+            target_path=target_path,
+            overwrite=True,
+            asset_id=asset_record.asset_id,
+            target_filename="hero.webp"
+        )
+        
+        # Verify file was copied
+        assert target_path.exists()
+        assert target_path.read_text() == "test image content"
+    
+    def test_full_publish_workflow_library_mode(self, tmp_path, asset_registry):
+        """Test full publish workflow in library mode with manifest"""
+        # Setup ComfyUI output
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        source_file = output_root / "test.png"
+        source_file.write_text("test image content")
+        
+        # Setup publish config
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        # Register asset
+        asset_record = asset_registry.register_asset(
+            filename="test.png",
+            subfolder="",
+            folder_type="output",
+            workflow_id="generate_image",
+            prompt_id="test_prompt_123",
+            mime_type="image/png"
+        )
+        
+        # Publish asset (library mode - auto-generate filename)
+        source_path = manager.resolve_source_path(
+            subfolder=asset_record.subfolder,
+            filename=asset_record.filename
+        )
+        auto_filename = auto_generate_filename(asset_record.asset_id)
+        target_path = manager.resolve_target_path(auto_filename)
+        
+        publish_info = manager.copy_asset(
+            source_path=source_path,
+            target_path=target_path,
+            overwrite=True,
+            asset_id=asset_record.asset_id,
+            target_filename=auto_filename
+        )
+        
+        # Update manifest
+        manager.update_manifest("hero-image", target_path.name)
+        
+        # Verify manifest was updated
+        manifest_path = config.publish_root / "manifest.json"
+        assert manifest_path.exists()
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+        assert manifest["hero-image"] == target_path.name
+    
+    def test_publish_rejects_expired_asset(self, tmp_path, asset_registry):
+        """Test that publishing rejects expired assets"""
+        from datetime import datetime, timedelta
+        
+        # Register and immediately expire
+        asset_record = asset_registry.register_asset(
+            filename="test.png",
+            subfolder="",
+            folder_type="output",
+            workflow_id="generate_image",
+            prompt_id="test_prompt_123"
+        )
+        
+        # Manually expire the asset
+        asset_record.expires_at = datetime.now() - timedelta(hours=1)
+        
+        # Asset should not be found
+        found = asset_registry.get_asset(asset_record.asset_id)
+        assert found is None
+    
+    def test_publish_rejects_path_traversal(self, tmp_path):
+        """Test that publishing rejects path traversal attempts"""
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        
+        # Create file outside output root
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        outside_file = outside / "malicious.png"
+        outside_file.write_text("malicious")
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        # Try to access file outside root via traversal
+        with pytest.raises(ValueError, match="outside ComfyUI output root"):
+            manager.resolve_source_path(subfolder="../../outside", filename="malicious.png")
+    
+    def test_publish_log_append(self, tmp_path):
+        """Test that publish log appends multiple entries"""
+        output_root = tmp_path / "comfyui" / "output"
+        output_root.mkdir(parents=True)
+        source1 = output_root / "test1.png"
+        source1.write_text("test1")
+        source2 = output_root / "test2.png"
+        source2.write_text("test2")
+        
+        config = PublishConfig(
+            project_root=tmp_path,
+            publish_root=tmp_path / "publish",
+            comfyui_output_root=output_root
+        )
+        manager = PublishManager(config)
+        
+        # Publish first asset
+        target1 = manager.resolve_target_path("test1.webp")
+        manager.copy_asset(source1, target1, asset_id="asset1", target_filename="test1.webp")
+        
+        # Publish second asset
+        target2 = manager.resolve_target_path("test2.webp")
+        manager.copy_asset(source2, target2, asset_id="asset2", target_filename="test2.webp")
+        
+        # Verify log has both entries
+        log_path = config.publish_root / "publish_log.jsonl"
+        assert log_path.exists()
+        
+        with open(log_path) as f:
+            lines = f.readlines()
+        
+        assert len(lines) == 2
+        entry1 = json.loads(lines[0])
+        entry2 = json.loads(lines[1])
+        assert entry1["target_filename"] == "test1.webp"
+        assert entry2["target_filename"] == "test2.webp"

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -1,0 +1,263 @@
+"""Publish tools for safely publishing ComfyUI assets to web project directories"""
+
+import logging
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from managers.publish_manager import (
+    PublishManager,
+    auto_generate_filename,
+    validate_manifest_key,
+    validate_target_filename
+)
+
+logger = logging.getLogger("MCP_Server")
+
+
+def register_publish_tools(
+    mcp: FastMCP,
+    asset_registry,
+    publish_manager: PublishManager
+):
+    """Register publish tools with the MCP server"""
+    
+    @mcp.tool()
+    def get_publish_info() -> dict:
+        """Get publish configuration and status information.
+        
+        This tool helps debug configuration issues and surfaces wrong assumptions
+        immediately. Call this first to verify publish setup before attempting to publish.
+        
+        Returns:
+            Dict with:
+            - project_root: Detected project root (path and detection method: "cwd" | "auto-detected")
+            - publish_root: Publish directory (path, exists, writable)
+            - comfyui_output_root: ComfyUI output root (path or None, detection method, configured flag)
+            - comfyui_tried_paths: List of paths checked during detection with validation results
+            - config_file: Path to persistent config file
+            - status: "ready" | "needs_comfyui_root" | "error"
+            - message: Human-readable status/instructions
+            - warnings: List of warnings (e.g., "Using fallback project root detection")
+            - error_code: Machine-readable error code (if not ready)
+        """
+        return publish_manager.get_publish_info()
+    
+    @mcp.tool()
+    def set_comfyui_output_root(path: str) -> dict:
+        """Set ComfyUI output root directory in persistent configuration.
+        
+        This tool configures the ComfyUI output directory once, and it will be remembered
+        across server restarts. Use this when auto-detection fails or you want explicit control.
+        
+        The path is validated to ensure:
+        - It exists and is a directory
+        - It appears to be a ComfyUI output directory (contains ComfyUI_*.png files or output/temp subdirs)
+        
+        Configuration is stored in a platform-specific location:
+        - Windows: %APPDATA%/comfyui-mcp-server/publish_config.json
+        - Mac: ~/Library/Application Support/comfyui-mcp-server/publish_config.json
+        - Linux: ~/.config/comfyui-mcp-server/publish_config.json
+        
+        Args:
+            path: Absolute or relative path to ComfyUI output directory
+                (e.g., "E:/comfyui-desktop/output" or "/opt/ComfyUI/output")
+        
+        Returns:
+            Dict with:
+            - success: True if configured successfully
+            - path: Resolved absolute path
+            - config_file: Path to config file where setting was saved
+            - message: Human-readable status message
+            - error: Error code if configuration failed
+        """
+        return publish_manager.set_comfyui_output_root(path)
+    
+    @mcp.tool()
+    def publish_asset(
+        asset_id: str,
+        target_filename: Optional[str] = None,
+        manifest_key: Optional[str] = None,
+        format: str = "webp",
+        max_bytes: int = 600_000,
+        overwrite: bool = True
+    ) -> dict:
+        """Publish a ComfyUI-generated asset to a web project directory.
+        
+        Supports two modes:
+        - **Demo mode**: Provide `target_filename` (e.g., "hero.webp") - deterministic filename
+        - **Library mode**: Omit `target_filename`, provide `manifest_key` - auto-generates filename
+        
+        **Safety guarantees:**
+        - Only assets from current session can be published (asset_id must exist in registry)
+        - Source path must be within ComfyUI output root (validated with real path resolution)
+        - Target filename validated by strict regex (prevents path traversal)
+        - All paths are canonicalized to prevent symlink/traversal attacks
+        - Images automatically compressed to meet size limits (deterministic compression ladder)
+        
+        **Workflow:**
+        1. Agent calls `generate_image` → gets `asset_id`
+        2. Agent calls `list_assets(session_id=...)` to discover assets
+        3. Agent calls `publish_asset(asset_id, target_filename="hero.webp")` (demo mode)
+           OR `publish_asset(asset_id, manifest_key="hero")` (library mode)
+        4. Server validates, compresses if needed, copies, and updates manifest.json
+        
+        Args:
+            asset_id: Asset ID from generation tools (session-scoped, dies on restart)
+            target_filename: Optional target filename (e.g., "hero.webp"). If omitted, auto-generated.
+                Must match regex: ^[a-z0-9][a-z0-9._-]{0,63}\.(webp|png|jpg|jpeg)$
+            manifest_key: Optional manifest key (required if target_filename omitted).
+                Must match regex: ^[a-z0-9][a-z0-9._-]{0,63}$
+            format: Target image format (default: "webp"). Ignored if target_filename has extension.
+            max_bytes: Maximum file size in bytes (default: 600000). Images are compressed if needed.
+            overwrite: Whether to overwrite existing file (default: True)
+        
+        Returns:
+            Dict with published file info:
+            - dest_url: Relative URL (e.g., "/gen/hero.webp")
+            - dest_path: Absolute path to published file
+            - bytes_size: File size in bytes
+            - mime_type: MIME type (e.g., "image/webp")
+            - width: Image width (if available)
+            - height: Image height (if available)
+            - compression_info: Compression details (if image was compressed)
+        
+        Raises:
+            Error dict with "error" and "error_code" keys if:
+            - Asset not found or expired (ASSET_NOT_FOUND_OR_EXPIRED)
+            - Invalid target_filename format (INVALID_TARGET_FILENAME)
+            - manifest_key required but missing (MANIFEST_KEY_REQUIRED)
+            - Source path outside ComfyUI outputs (SOURCE_PATH_OUTSIDE_ROOT)
+            - Path traversal attempt detected (PATH_TRAVERSAL_DETECTED)
+            - Copy/compression operation fails (PUBLISH_FAILED)
+        """
+        # Cleanup expired assets
+        asset_registry.cleanup_expired()
+        
+        # Check readiness first
+        is_ready, error_code, error_info = publish_manager.ensure_ready()
+        if not is_ready:
+            return {
+                "error": error_info.get("message", "Publish manager not ready"),
+                "error_code": error_code,
+                **error_info
+            }
+        
+        # Lookup asset in registry (session-scoped)
+        asset_record = asset_registry.get_asset(asset_id)
+        if not asset_record:
+            return {
+                "error": f"Asset {asset_id} not found or expired. Assets are session-scoped and die on server restart. Generate a new asset in the current session.",
+                "error_code": "ASSET_NOT_FOUND_OR_EXPIRED"
+            }
+        
+        try:
+            # Resolve source path from asset metadata
+            source_path = publish_manager.resolve_source_path(
+                subfolder=asset_record.subfolder,
+                filename=asset_record.filename
+            )
+            
+            # Determine target filename
+            if target_filename:
+                # Demo mode: use provided filename
+                if not validate_target_filename(target_filename):
+                    return {
+                        "error": f"Invalid target_filename: '{target_filename}'. Must match regex: ^[a-z0-9][a-z0-9._-]{{0,63}}\\.(webp|png|jpg|jpeg)$",
+                        "error_code": "INVALID_TARGET_FILENAME"
+                    }
+                final_target_filename = target_filename
+            else:
+                # Library mode: auto-generate filename, manifest_key is required
+                if not manifest_key:
+                    return {
+                        "error": "manifest_key is required when target_filename is omitted (library mode). Provide either target_filename or manifest_key.",
+                        "error_code": "MANIFEST_KEY_REQUIRED"
+                    }
+                if not validate_manifest_key(manifest_key):
+                    return {
+                        "error": f"Invalid manifest_key: '{manifest_key}'. Must match regex: ^[a-z0-9][a-z0-9._-]{{0,63}}$",
+                        "error_code": "INVALID_MANIFEST_KEY"
+                    }
+                # Auto-generate filename
+                final_target_filename = auto_generate_filename(asset_id)
+                # Extract format from generated filename or use provided format
+                if format and not final_target_filename.endswith(f".{format}"):
+                    final_target_filename = final_target_filename.rsplit(".", 1)[0] + f".{format}"
+            
+            # Resolve target path
+            target_path = publish_manager.resolve_target_path(final_target_filename)
+            
+            # Determine format from target filename extension
+            target_ext = target_path.suffix.lower().lstrip(".")
+            if target_ext in ("webp", "png", "jpg", "jpeg"):
+                actual_format = target_ext
+            else:
+                actual_format = format
+            
+            # Copy asset with compression if needed
+            publish_info = publish_manager.copy_asset(
+                source_path=source_path,
+                target_path=target_path,
+                overwrite=overwrite,
+                asset_id=asset_id,
+                target_filename=final_target_filename,
+                format=actual_format,
+                max_bytes=max_bytes
+            )
+            
+            # Update manifest.json if manifest_key provided
+            if manifest_key:
+                try:
+                    publish_manager.update_manifest(
+                        manifest_key=manifest_key,
+                        filename=target_path.name
+                    )
+                except Exception as e:
+                    # Manifest update failure is non-fatal
+                    logger.warning(f"Failed to update manifest for key {manifest_key}: {e}")
+            
+            # Add image dimensions if available
+            result = {
+                "dest_url": publish_info["dest_url"],
+                "dest_path": publish_info["dest_path"],
+                "bytes_size": publish_info["bytes_size"],
+                "mime_type": publish_info["mime_type"]
+            }
+            
+            if "compression_info" in publish_info:
+                result["compression_info"] = publish_info["compression_info"]
+            
+            if asset_record.width and asset_record.height:
+                result["width"] = asset_record.width
+                result["height"] = asset_record.height
+            
+            logger.info(
+                f"Published asset {asset_id} to {final_target_filename}: {publish_info['dest_url']} "
+                f"({publish_info['bytes_size']} bytes)"
+            )
+            
+            return result
+            
+        except ValueError as e:
+            # Path validation errors
+            error_msg = str(e)
+            if "outside" in error_msg.lower() or "COMFYUI_OUTPUT_ROOT" in error_msg:
+                error_code = "SOURCE_PATH_OUTSIDE_ROOT"
+            elif "traversal" in error_msg.lower() or ".." in error_msg:
+                error_code = "PATH_TRAVERSAL_DETECTED"
+            elif "Invalid target_filename" in error_msg:
+                error_code = "INVALID_TARGET_FILENAME"
+            else:
+                error_code = "VALIDATION_ERROR"
+            
+            return {
+                "error": error_msg,
+                "error_code": error_code
+            }
+        except Exception as e:
+            logger.exception(f"Failed to publish asset {asset_id}")
+            return {
+                "error": f"Failed to publish asset: {str(e)}",
+                "error_code": "PUBLISH_FAILED"
+            }


### PR DESCRIPTION
## Summary

This PR adds a safe, plug-and-play asset publishing pipeline for ComfyUI outputs.

Agents can now publish generated images directly into a web project’s static
directory (e.g. `public/gen`) for live localhost previews, without relying on
`view_image`, base64 blobs, or manual file copying.

## Key Features

- **New publish tools**
  - `get_publish_info` – inspect detected project root, publish dir, and ComfyUI output root
  - `set_comfyui_output_root` – one-time configuration for nonstandard installs (persisted)
  - `publish_asset` – publish a generated asset with deterministic compression

- **Zero-config defaults (common case)**
  - Auto-detects project root from cwd
  - Publishes to `public/gen` (fallbacks: `static/gen`, `assets/gen`)
  - Tools always register; config validated at call time

- **Safety guarantees**
  - No raw paths accepted from the agent
  - Flat filename validation (no traversal, no subdirs)
  - Source files must originate from ComfyUI outputs
  - Atomic writes (temp + rename)
  - Session-scoped `asset_id`s (expire on restart)

- **Practical UX**
  - Automatic WebP compression (default 600KB, deterministic ladder)
  - Optional `manifest.json` updates for hot-swapping assets in the browser
  - Clear error messages with actionable setup instructions

## Motivation

This enables live visual demos and web previews driven by Cursor + MCP without
pulling images into chat context or relying on fragile filesystem conventions.
It keeps the agent text-first while the browser becomes the vision surface.

## Notes

- `asset_id`s are ephemeral and valid only for the current server session.
- ComfyUI output root auto-detection is best-effort; use
  `set_comfyui_output_root` once for Comfy Desktop or custom installs.

See `docs/HOW_TO_TEST_PUBLISH.md` for usage and testing instructions.
