### PR TITLE
upgrade fastmcp version to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 requests>=2.31.0
-mcp>=0.9.0
+fastmcp
 
 # Image processing (required for view_image tool)
 Pillow>=10.0.0

--- a/server.py
+++ b/server.py
@@ -10,7 +10,7 @@ from typing import AsyncIterator
 
 import requests
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from comfyui_client import ComfyUIClient
 from managers.asset_registry import AssetRegistry
@@ -181,13 +181,9 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 
 
 # Initialize FastMCP with lifespan and port configuration
-# Using port 9000 for consistency with previous version
-# Enable stateless_http to avoid requiring session management
 mcp = FastMCP(
     "ComfyUI_MCP_Server",
     lifespan=app_lifespan,
-    port=9000,
-    stateless_http=True
 )
 
 # Register all MCP tools
@@ -231,6 +227,6 @@ if __name__ == "__main__":
         logger.info("Starting MCP server with streamable-http transport on http://127.0.0.1:9000/mcp")
         logger.info(f"ComfyUI verified at: {COMFYUI_URL}")
         try:
-            mcp.run(transport="streamable-http")
+            mcp.run(transport="streamable-http", port=9000, stateless_http=True)
         except KeyboardInterrupt:
             print("\n[*] Server stopped.")

--- a/tests/test_job_tools.py
+++ b/tests/test_job_tools.py
@@ -2,7 +2,7 @@
 import pytest
 from unittest.mock import Mock
 from tools.job import register_job_tools
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 
 @pytest.fixture

--- a/tools/asset.py
+++ b/tools/asset.py
@@ -3,7 +3,8 @@
 import logging
 from typing import Optional
 
-from mcp.server.fastmcp import FastMCP, Image as FastMCPImage
+from fastmcp import FastMCP
+from fastmcp.utilities.types import Image as FastMCPImage
 from asset_processor import (
     encode_preview_for_mcp,
     estimate_response_chars,

--- a/tools/configuration.py
+++ b/tools/configuration.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 
 def register_configuration_tools(

--- a/tools/generation.py
+++ b/tools/generation.py
@@ -6,7 +6,7 @@ import logging
 import random
 from typing import Any, Dict, Optional
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from managers.workflow_manager import AUDIO_OUTPUT_KEYS, VIDEO_OUTPUT_KEYS
 from models.workflow import WorkflowToolDefinition
 from tools.helpers import register_and_build_response

--- a/tools/job.py
+++ b/tools/job.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 logger = logging.getLogger("MCP_Server")
 

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from managers.publish_manager import (
     PublishManager,

--- a/tools/workflow.py
+++ b/tools/workflow.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Dict, Optional
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from tools.helpers import register_and_build_response
 
 logger = logging.getLogger("MCP_Server")


### PR DESCRIPTION
This PR upgrades fastmcp version to the latest version, 1.26->3.0.2.  This has a ton of bug fixes, security patches and allows better control over the server.
- change image type path
- new version moves port and stateless config to 'run'

[Official guidelines](https://gofastmcp.com/getting-started/upgrading/from-mcp-sdk)

```
❯ python test_client.py 

============================================================
               ComfyUI MCP Server Test Client               
============================================================

============================================================
                 Listing available tools...                 
============================================================

Available tools (17):
  • list_models: List all available checkpoint models in ComfyUI.
  • get_defaults: Get current effective defaults for image, audio, and video generation.
  • set_defaults: Set runtime defaults for image, audio, and/or video generation.
  • list_workflows: List all available workflows in the workflow directory.
  • run_workflow: Run a saved ComfyUI workflow with constrained parameter overrides.
  • view_image: View a generated image inline in chat (thumbnail preview only).
  • generate_image: Execute the 'generate image' ComfyUI workflow.
  • generate_song: Execute the 'generate song' ComfyUI workflow.
  • regenerate: Regenerate an existing asset with optional parameter overrides.
  • get_queue_status: Get the current ComfyUI queue status.
  • get_job: Get job status and history for a specific prompt ID.
  • list_assets: List recently generated assets for AI memory and browsing.
  • get_asset_metadata: Get full metadata and provenance for a generated asset.
  • cancel_job: Cancel a queued or running job.
  • get_publish_info: Get publish configuration and status information.
  • set_comfyui_output_root: Set ComfyUI output root directory in persistent configuration.
  • publish_asset: Publish a ComfyUI-generated asset to a web project directory.

============================================================
                Fetching server defaults...                 
============================================================

  Calling tool 'get_defaults'
Arguments: {}

[+] Response from server:
{
  "content": [
    {
      "type": "text",
      "text": {
        "image": {
          "width": 512,
          "height": 512,
          "steps": 20,
          "cfg": 8.0,
          "sampler_name": "euler",
          "scheduler": "normal",
          "denoise": 1.0,
          "model": "v1-5-pruned-emaonly.ckpt",
          "negative_prompt": "text, watermark"
        },
        "audio": {
          "steps": 50,
          "cfg": 5.0,
          "sampler_name": "euler",
          "scheduler": "simple",
          "denoise": 1.0,
          "seconds": 60,
          "lyrics_strength": 0.99,
          "model": "ace_step_v1_3.5b.safetensors"
        },
        "video": {
          "width": 1280,
          "height": 720,
          "steps": 20,
          "cfg": 8.0,
          "sampler_name": "euler",
          "scheduler": "normal",
          "denoise": 1.0,
          "negative_prompt": "text, watermark",
          "duration": 5,
          "fps": 16
        }
      }
    }
  ],
  "structuredContent": {
    "image": {
      "width": 512,
      "height": 512,
      "steps": 20,
      "cfg": 8.0,
      "sampler_name": "euler",
      "scheduler": "normal",
      "denoise": 1.0,
      "model": "v1-5-pruned-emaonly.ckpt",
      "negative_prompt": "text, watermark"
    },
    "audio": {
      "steps": 50,
      "cfg": 5.0,
      "sampler_name": "euler",
      "scheduler": "simple",
      "denoise": 1.0,
      "seconds": 60,
      "lyrics_strength": 0.99,
      "model": "ace_step_v1_3.5b.safetensors"
    },
    "video": {
      "width": 1280,
      "height": 720,
      "steps": 20,
      "cfg": 8.0,
      "sampler_name": "euler",
      "scheduler": "normal",
      "denoise": 1.0,
      "negative_prompt": "text, watermark",
      "duration": 5,
      "fps": 16
    }
  },
  "isError": false
}
   Using server defaults: width=512, height=512, steps=20, model=v1-5-pruned-emaonly.ckpt

============================================================
              Testing tool 'generate_image'...              
============================================================

  Calling tool 'generate_image'
Arguments: {
  "prompt": "an english mastiff dog, mouth closed, standing majestically in a grassy field, bright shiny day, forest background"
}

[+] Response from server:
{
  "content": [
    {
      "type": "text",
      "text": {
        "error": "Default model 'v1-5-pruned-emaonly.ckpt' (from hardcoded defaults) not found in ComfyUI checkpoints. Set a valid model via `set_defaults`, config file, or env var. Try `list_models` to see available checkpoints. Available models: ['v1-5-pruned-emaonly-fp16.safetensors']"
      }
    }
  ],
  "structuredContent": {
    "error": "Default model 'v1-5-pruned-emaonly.ckpt' (from hardcoded defaults) not found in ComfyUI checkpoints. Set a valid model via `set_defaults`, config file, or env var. Try `list_models` to see available checkpoints. Available models: ['v1-5-pruned-emaonly-fp16.safetensors']"
  },
  "isError": false
}

============================================================
                        Test Results                        
============================================================
[+] Test completed successfully!
```

```
❯ pytest -v
============================================================= test session starts ==============================================================
platform linux -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0 -- /home/mike/code/mcp/venv/bin/python
cachedir: .pytest_cache
rootdir: /home/mike/code/mcp/comfyui-mcp-server
plugins: anyio-4.12.1
collected 87 items                                                                                                                             

test_client.py::test_generate_image PASSED                                                                                               [  1%]
tests/test_asset_registry.py::test_register_and_lookup PASSED                                                                            [  2%]
tests/test_asset_registry.py::test_special_characters_in_filename PASSED                                                                 [  3%]
tests/test_asset_registry.py::test_duplicate_filename_handling PASSED                                                                    [  4%]
tests/test_asset_registry.py::test_list_assets_filtering PASSED                                                                          [  5%]
tests/test_asset_registry.py::test_asset_expiration PASSED                                                                               [  6%]
tests/test_asset_registry.py::test_empty_subfolder PASSED                                                                                [  8%]
tests/test_asset_registry.py::test_provenance_storage PASSED                                                                             [  9%]
tests/test_basic.py::test_asset_url_encoding PASSED                                                                                      [ 10%]
tests/test_basic.py::test_asset_identity_lookup PASSED                                                                                   [ 11%]
tests/test_basic.py::test_list_assets PASSED                                                                                             [ 12%]
tests/test_basic.py::test_asset_url_base_url_normalization PASSED                                                                        [ 13%]
tests/test_bug_fixes.py::TestWorkflowCacheMtime::test_load_workflow_detects_file_change PASSED                                           [ 14%]
tests/test_bug_fixes.py::TestWorkflowCacheMtime::test_render_workflow_refreshes_stale_definition PASSED                                  [ 16%]
tests/test_bug_fixes.py::TestWorkflowCacheMtime::test_cache_hit_when_file_unchanged PASSED                                               [ 17%]
tests/test_bug_fixes.py::TestModelValidationSkip::test_audio_workflow_has_no_model_param PASSED                                          [ 18%]
tests/test_bug_fixes.py::TestModelValidationSkip::test_output_preferences_detected_as_audio PASSED                                       [ 19%]
tests/test_bug_fixes.py::TestErrorDiagnostics::test_extract_structured_execution_error PASSED                                            [ 20%]
tests/test_bug_fixes.py::TestErrorDiagnostics::test_extract_top_level_error PASSED                                                       [ 21%]
tests/test_bug_fixes.py::TestErrorDiagnostics::test_extract_no_info_fallback PASSED                                                      [ 22%]
tests/test_bug_fixes.py::TestErrorDiagnostics::test_has_status_message_list_format PASSED                                                [ 24%]
tests/test_bug_fixes.py::TestErrorDiagnostics::test_has_status_message_empty PASSED                                                      [ 25%]
tests/test_bug_fixes.py::TestTimeoutJobHandle::test_wait_for_prompt_returns_none_on_timeout PASSED                                       [ 26%]
tests/test_bug_fixes.py::TestTimeoutJobHandle::test_run_custom_workflow_returns_running_on_timeout PASSED                                [ 27%]
tests/test_bug_fixes.py::TestTimeoutJobHandle::test_helpers_pass_through_running_status PASSED                                           [ 28%]
tests/test_bug_fixes.py::TestOverrideMismatchReporting::test_unmatched_overrides_are_reported PASSED                                     [ 29%]
tests/test_bug_fixes.py::TestOverrideMismatchReporting::test_all_matched_overrides_no_drop_report PASSED                                 [ 31%]
tests/test_edge_cases.py::test_empty_comfyui_history PASSED                                                                              [ 32%]
tests/test_edge_cases.py::test_very_long_filename PASSED                                                                                 [ 33%]
tests/test_edge_cases.py::test_unicode_characters_in_filename PASSED                                                                     [ 34%]
tests/test_edge_cases.py::test_multiple_assets_same_workflow PASSED                                                                      [ 35%]
tests/test_edge_cases.py::test_asset_cleanup_on_expiration PASSED                                                                        [ 36%]
tests/test_edge_cases.py::test_base_url_with_different_ports PASSED                                                                      [ 37%]
tests/test_edge_cases.py::test_empty_metadata PASSED                                                                                     [ 39%]
tests/test_edge_cases.py::test_nested_subfolder PASSED                                                                                   [ 40%]
tests/test_job_tools.py::test_get_queue_status_integration PASSED                                                                        [ 41%]
tests/test_job_tools.py::test_get_job_running_scenario PASSED                                                                            [ 42%]
tests/test_job_tools.py::test_get_job_completed_scenario PASSED                                                                          [ 43%]
tests/test_job_tools.py::test_get_job_not_found_scenario PASSED                                                                          [ 44%]
tests/test_job_tools.py::test_list_assets_integration PASSED                                                                             [ 45%]
tests/test_job_tools.py::test_cancel_job_integration PASSED                                                                              [ 47%]
tests/test_publish.py::TestPathSafety::test_canonicalize_path_absolute PASSED                                                            [ 48%]
tests/test_publish.py::TestPathSafety::test_canonicalize_path_relative PASSED                                                            [ 49%]
tests/test_publish.py::TestPathSafety::test_canonicalize_path_nonexistent PASSED                                                         [ 50%]
tests/test_publish.py::TestPathSafety::test_canonicalize_path_nonexistent_optional PASSED                                                [ 51%]
tests/test_publish.py::TestPathSafety::test_is_within_simple PASSED                                                                      [ 52%]
tests/test_publish.py::TestPathSafety::test_is_within_nested PASSED                                                                      [ 54%]
tests/test_publish.py::TestPathSafety::test_is_within_outside PASSED                                                                     [ 55%]
tests/test_publish.py::TestPathSafety::test_is_within_traversal_attempt PASSED                                                           [ 56%]
tests/test_publish.py::TestPathSafety::test_is_within_same_path PASSED                                                                   [ 57%]
tests/test_publish.py::TestPathSafety::test_is_within_nonexistent_child PASSED                                                           [ 58%]
tests/test_publish.py::TestValidationFunctions::test_validate_target_filename_valid PASSED                                               [ 59%]
tests/test_publish.py::TestValidationFunctions::test_validate_target_filename_invalid PASSED                                             [ 60%]
tests/test_publish.py::TestValidationFunctions::test_validate_manifest_key_valid PASSED                                                  [ 62%]
tests/test_publish.py::TestValidationFunctions::test_validate_manifest_key_invalid PASSED                                                [ 63%]
tests/test_publish.py::TestValidationFunctions::test_auto_generate_filename PASSED                                                       [ 64%]
tests/test_publish.py::TestProjectRootDetection::test_detect_project_root_with_git PASSED                                                [ 65%]
tests/test_publish.py::TestProjectRootDetection::test_detect_project_root_with_public PASSED                                             [ 66%]
tests/test_publish.py::TestPublishConfig::test_init_minimal PASSED                                                                       [ 67%]
tests/test_publish.py::TestPublishConfig::test_init_with_project_root PASSED                                                             [ 68%]
tests/test_publish.py::TestPublishConfig::test_init_with_publish_root PASSED                                                             [ 70%]
tests/test_publish.py::TestPublishConfig::test_get_default_publish_root PASSED                                                           [ 71%]
tests/test_publish.py::TestPublishConfig::test_validate_comfyui_output_root PASSED                                                       [ 72%]
tests/test_publish.py::TestPublishConfig::test_validate_comfyui_output_root_with_images PASSED                                           [ 73%]
tests/test_publish.py::TestPersistentConfig::test_get_publish_config_dir PASSED                                                          [ 74%]
tests/test_publish.py::TestPersistentConfig::test_get_publish_config_file PASSED                                                         [ 75%]
tests/test_publish.py::TestPersistentConfig::test_save_and_load_publish_config PASSED                                                    [ 77%]
tests/test_publish.py::TestPublishManager::test_resolve_source_path_simple PASSED                                                        [ 78%]
tests/test_publish.py::TestPublishManager::test_resolve_source_path_with_subfolder PASSED                                                [ 79%]
tests/test_publish.py::TestPublishManager::test_resolve_source_path_outside_root PASSED                                                  [ 80%]
tests/test_publish.py::TestPublishManager::test_resolve_source_path_nonexistent PASSED                                                   [ 81%]
tests/test_publish.py::TestPublishManager::test_resolve_target_path PASSED                                                               [ 82%]
tests/test_publish.py::TestPublishManager::test_resolve_target_path_nonexistent PASSED                                                   [ 83%]
tests/test_publish.py::TestPublishManager::test_resolve_target_path_invalid_filename PASSED                                              [ 85%]
tests/test_publish.py::TestPublishManager::test_copy_asset_simple PASSED                                                                 [ 86%]
tests/test_publish.py::TestPublishManager::test_copy_asset_no_overwrite PASSED                                                           [ 87%]
tests/test_publish.py::TestPublishManager::test_copy_asset_no_compression_default PASSED                                                 [ 88%]
tests/test_publish.py::TestPublishManager::test_copy_asset_with_compression PASSED                                                       [ 89%]
tests/test_publish.py::TestPublishManager::test_update_manifest PASSED                                                                   [ 90%]
tests/test_publish.py::TestPublishManager::test_update_manifest_multiple_keys PASSED                                                     [ 91%]
tests/test_publish.py::TestPublishManager::test_ensure_ready PASSED                                                                      [ 93%]
tests/test_publish.py::TestPublishManager::test_ensure_ready_missing_comfyui_root PASSED                                                 [ 94%]
tests/test_publish.py::TestPublishIntegration::test_full_publish_workflow_demo_mode PASSED                                               [ 95%]
tests/test_publish.py::TestPublishIntegration::test_full_publish_workflow_library_mode PASSED                                            [ 96%]
tests/test_publish.py::TestPublishIntegration::test_publish_rejects_expired_asset PASSED                                                 [ 97%]
tests/test_publish.py::TestPublishIntegration::test_publish_rejects_path_traversal PASSED                                                [ 98%]
tests/test_publish.py::TestPublishIntegration::test_publish_log_append PASSED                                                            [100%]

============================================================== 87 passed in 2.79s ==============================================================
```

